### PR TITLE
fix the bug : not work on jp>4.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,8 +20,8 @@ Following scripts are included:
 
 
 ### Version Dependencies:
-- JetPack 4.4 <br />
-- TensorRT 7 <br />
+- JetPack 4.4 / 4.6 / 5.0 <br />
+- TensorRT 7/8<br />
 
 ### Set up instructions
 ``` git clone https://github.com/NVIDIA-AI-IOT/jetson_benchmarks.git``` <br />
@@ -87,6 +87,18 @@ sudo python3 benchmark.py --all --csv_file_path <path-to>/benchmark_csv/xavier-b
                           --model_dir <absolute-path-to-downloaded-models> \
                           --jetson_devkit xavier \
                           --gpu_freq 1377000000 --dla_freq 1395200000 --power_mode 0
+```
+
+# For Jetson Xavier NX
+Please follow setup, and installation requirements. <br/>
+
+### Download Models
+``` python3 utils/download_models.py --all --csv_file_path <path-to>/benchmark_csv/nx-benchmarks.csv --save_dir <absolute-path-to-downloaded-models>```
+
+### Running All Benchmark Models at Once on Jetson Xavier NX <br/>
+```
+# if Jetpack version >= 4.6 use flag `--power_mode 8`
+sudo python3 benchmark.py --all --csv_file_path <path-to>/benchmark_csv/nx-benchmarks.csv --model_dir <absolute-path-to-downloaded-models> --power_mode 0
 ```
 
 # For Jetson TX2 and Jeston Nano

--- a/benchmark.py
+++ b/benchmark.py
@@ -29,7 +29,7 @@ def main():
         system_check.set_jetson_fan(255)
 
     # Read CSV and Write Data
-    benchmark_data = read_write_data(csv_file_path=csv_file_path, model_path=model_path)
+    benchmark_data = read_write_data(csv_file_path=csv_file_path, model_path=model_path, trt_version=system_check.get_trt_version())
     if args.all:
         latency_each_model =[]
         print("Running all benchmarks.. This will take at least 2 hours...")

--- a/utils/benchmark_argparser.py
+++ b/utils/benchmark_argparser.py
@@ -17,6 +17,7 @@ class benchmark_argparser():
         # For Jetson Xavier: set to 0 (MAXN)
         # For Jetson TX2: set to 3 (MAXP)
         # For Jetson Nano: set to 0 (MAXN)
+        # For Jetson NX: for JP4.4 set to 0, JP4.6+ set to 8 (MAXN)
         self.parser.add_argument('--precision', dest='precision', default='int8',
                                  help='precision for model int8 or fp16', type=str)
         # For Jetson Xavier: set to int8

--- a/utils/utilities.py
+++ b/utils/utilities.py
@@ -2,6 +2,8 @@ import os
 import subprocess
 import sys
 import time
+import tensorrt
+
 FNULL = open(os.devnull, 'w')
 # Class for Utilities (TRT check, Power mode switching)
 # https://docs.nvidia.com/jetson/l4t/index.html#page/Tegra%2520Linux%2520Driver%2520Package%2520Development%2520Guide%2Fpower_management_jetson_xavier.html%23wwpID0E0KD0HA
@@ -24,8 +26,16 @@ class utilities():
         print("Jetson clocks are Set")
 
     def set_jetson_fan(self, switch_opt):
-        fan_cmd = "sh" + " " + "-c" + " " + "'echo" + " " + str(
-            switch_opt) + " " + ">" + " " + "/sys/devices/pwm-fan/target_pwm'"
+        nv_tegra_release_read = open("/etc/nv_tegra_release", "r")
+        release_value = int(nv_tegra_release_read.read().rstrip("\n")[3:5])
+        nv_tegra_release_read.close()
+        # for jp>=5.0 the pwm-fan changed
+        if release_value <=32:
+            fan_cmd = "sh" + " " + "-c" + " " + "'echo" + " " + str(
+                switch_opt) + " " + ">" + " " + "/sys/devices/pwm-fan/target_pwm'"
+        else:
+            fan_cmd = "sh" + " " + "-c" + " " + "'echo" + " " + str(
+              switch_opt) + " " + ">" + " " + "/sys/devices/platform/pwm-fan/hwmon/hwmon4/pwm1'"
         subprocess.call('sudo {}'.format(fan_cmd), shell=True, stdout=FNULL)
 
     def run_set_clocks_withDVFS(self):
@@ -105,3 +115,5 @@ class utilities():
             print("Exiting. Check if TensorRT is installed \n Use ``dpkg -l | grep nvinfer`` ")
             return True
         return False
+    def get_trt_version(self):
+        return tensorrt.__version__


### PR DESCRIPTION
1. tensorrt8  instead "end-to-end" metric with "Host lantency", use py-tensorrt to get the version of tensorrt
2. for jp>5.0(rel-34), the pwn_fan changed
3. NX add a new power-mode (nvpmodel 8) as the MAXN power mode, update this in README.md
4. write the convert-log to file as well which can help to debug
5. fix warning: jetson_benchmarks/utils/read_write_data.py:126: SyntaxWarning: "is" with a literal. Did you mean "=="?