### PR TITLE
Fixes Path For Fan Control 

### DIFF
--- a/utils/utilities.py
+++ b/utils/utilities.py
@@ -24,9 +24,17 @@ class utilities():
         print("Jetson clocks are Set")
 
     def set_jetson_fan(self, switch_opt):
-        fan_cmd = "sh" + " " + "-c" + " " + "'echo" + " " + str(
-            switch_opt) + " " + ">" + " " + "/sys/devices/pwm-fan/target_pwm'"
-        subprocess.call('sudo {}'.format(fan_cmd), shell=True, stdout=FNULL)
+
+        if os.path.exists('/sys/devices/pwm-fan/'): 
+            fan_cmd = "sh" + " " + "-c" + " " + "'echo" + " " + str(
+                switch_opt) + " " + ">" + " " + "/sys/devices/pwm-fan/target_pwm'"
+            subprocess.call('sudo {}'.format(fan_cmd), shell=True, stdout=FNULL)
+        else: 
+            hwmon_dir_num = os.listdir("/sys/devices/platform/pwm-fan/hwmon")[0]
+            fan_cmd = "sh" + " " + "-c" + " " + "'echo" + " " + str(
+                switch_opt) + " " + ">" + " " + "/sys/devices/platform/pwm-fan/hwmon/hwmon" + str(hwmon_dir_num) +"/pwm1'"
+            subprocess.call('sudo {}'.format(fan_cmd), shell=True, stdout=FNULL)
+
 
     def run_set_clocks_withDVFS(self):
         if self.jetson_devkit == 'tx2':


### PR DESCRIPTION
Jetpack R35
Jetson Nano Xavier NX 

When I ran the benchmarks:

```
Traceback (most recent call last):
  File "benchmark.py", line 130, in <module>
    main()
  File "benchmark.py", line 28, in main
    system_check.run_set_clocks_withDVFS()
  File "/home/jetson/Documents/jetson_benchmarks/utils/utilities.py", line 53, in run_set_clocks_withDVFS
    self.set_clocks_withDVFS(frequency=self.gpu_freq, device='gpu')
  File "/home/jetson/Documents/jetson_benchmarks/utils/utilities.py", line 82, in set_clocks_withDVFS
    from_freq = self.read_internal_register(register=freq_register_, device=device)
  File "/home/jetson/Documents/jetson_benchmarks/utils/utilities.py", line 108, in read_internal_register
    reg_read = open(register, "r")
FileNotFoundError: [Errno 2] No such file or directory: '/sys/kernel/debug/bpmp/debug/clk/nafll_gpc0/rate'
```

This occurs because `/sys/kernel/debug/bpmp/debug/clk/nafll_gpc0/rate` does not exist in this version of jetpack. I noticed from the Nvidia documentation that fan control is done via hwmon: https://docs.nvidia.com/jetson/archives/r35.1/DeveloperGuide/text/SD/PlatformPowerAndPerformance/JetsonOrinNxSeriesAndJetsonAgxOrinSeries.html#fan-speed-control