### PR TITLE
Fix incompatible data type in DataFrame creation

### DIFF
--- a/benchmark.py
+++ b/benchmark.py
@@ -46,7 +46,7 @@ def main():
                     model.remove()
             del gc.garbage[:]
             system_check.clear_ram_space()
-        benchmark_table = pd.DataFrame(latency_each_model, columns=['GPU (ms)', 'DLA0 (ms)', 'DLA1 (ms)', 'FPS', 'Model Name'], dtype=float)
+        benchmark_table = pd.DataFrame(latency_each_model, columns=['GPU (ms)', 'DLA0 (ms)', 'DLA1 (ms)', 'FPS', 'Model Name'])
         # Note: GPU, DLA latencies are measured in miliseconds, FPS = Frames per Second
         print(benchmark_table[['Model Name', 'FPS']])
         if args.plot:


### PR DESCRIPTION
Do not specify a dtype when creating a DataFrame when the table has heterogeneous data types.  In this case, the table has float and string types.